### PR TITLE
fix responseApprovalTemplate config

### DIFF
--- a/src/work/oa/response/responseApprovalTemplate.go
+++ b/src/work/oa/response/responseApprovalTemplate.go
@@ -1,6 +1,7 @@
 package response
 
 import (
+	"github.com/ArtisanCloud/PowerWeChat/v2/src/kernel/power"
 	"github.com/ArtisanCloud/PowerWeChat/v2/src/kernel/response"
 )
 
@@ -33,19 +34,9 @@ type Option struct {
 	Value []*Value `json:"value"`
 }
 
-type Selector struct {
-	Type    string    `json:"type"`
-	ExpType int       `json:"exp_type"`
-	Options []*Option `json:"options"`
-}
-
-type Config struct {
-	Selector *Selector `json:"selector"`
-}
-
 type Control struct {
-	Property *Property `json:"property"`
-	Config   *Config   `json:"config"`
+	Property *Property      `json:"property"`
+	Config   *power.HashMap `json:"config"`
 }
 
 type TemplateContent struct {


### PR DESCRIPTION
control 中的 config 是一个 oneof 类型, Selector只是其中之一, 而且该属性以后也有可能新增子类型, 可以使用map自行获取而不必使用强类型