### PR TITLE
feat(kernal): baseClient request supported context query params

### DIFF
--- a/src/kernel/baseClient.go
+++ b/src/kernel/baseClient.go
@@ -226,6 +226,16 @@ func (client *BaseClient) Request(ctx context.Context, url string, method string
 		}
 	}
 
+	ctxQuery := ctx.Value("query")
+	if ctxQuery != nil {
+		queries := ctxQuery.(*object.StringMap)
+		if queries != nil {
+			for k, v := range *queries {
+				df.Query(k, v)
+			}
+		}
+	}
+
 	response, err := df.Request()
 	if err != nil {
 		return response, err


### PR DESCRIPTION
**遇到的问题：**

当前 SDK 服务商模式（第三方应用开发和服务商代开发）不完整支持，我这边需要用到代开发模式

> 目前自己管理的代开发应用授权流程和鉴权凭据，并通过 context 注入`provider_access_token` 实现支持

**实现的功能：**

支持通过 context 注入额外的请求参数

**应用场景：**

通过全局注入服务商 Token，支持代开发模式接口访问
> 代开发自建应用模式，仍然是企业自建应用那套 API，区别在于鉴权方式不同，需要额外的服务商 Token

**使用示例：**

代开发模式，注入 `provider_access_token` 

```go
func GetWecomApp(ctx *gin.Context, data ...string) (app *work.Work) {
    ......
    accessToken := WorkAgent.ProviderAccessToken.Get().AccessToken
    ctx.Set("query", &object.StringMap{
        "provider_access_token": accessToken,
    })
    ......
}
```