### PR TITLE
fix(work): base jssdk cache & work jssdk config fixed

### DIFF
--- a/src/work/jssdk/client.go
+++ b/src/work/jssdk/client.go
@@ -18,18 +18,11 @@ func NewClient(app *kernel.ApplicationInterface) (*Client, error) {
 		jssdkClient,
 	}
 
-	config := (*app).GetConfig()
-	baseURI := config.GetString("http.base_uri", "/")
-
-	client.TicketEndpoint = baseURI + "/cgi-bin/get_jsapi_ticket"
+	client.TicketEndpoint = "cgi-bin/get_jsapi_ticket"
 
 	return client, nil
 }
 
-func (comp *Client) GetAppID() string {
-	config := (*comp.BaseClient.App).GetConfig()
-	return config.GetString("corp_id", "")
-}
 
 func (comp *Client) GetAgentConfigArray() {
 

--- a/src/work/jssdk/provider.go
+++ b/src/work/jssdk/provider.go
@@ -1,18 +1,15 @@
 package jssdk
 
 import (
-	"github.com/ArtisanCloud/PowerWeChat/v3/src/basicService/jssdk"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/kernel"
 )
 
 func RegisterProvider(app kernel.ApplicationInterface) (*Client, error) {
 
-	jssdkClient, err := jssdk.NewClient(&app)
+	jssdkClient, err := NewClient(&app)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{
-		jssdkClient,
-	}, nil
+	return jssdkClient, nil
 
 }


### PR DESCRIPTION
1. 修复 base jssdk 未使用配置的缓存驱动问题
2. 修复企微 jssdk 获取错误问题
2.1 work/jssdk/provider 错误使用了 base jssdk，调整为 work 下对应的 jssdk/client
2.2 移除 work/jssdk/client 的 GetAppID()，这里调不到，base 方法里调用的仍然会是 base 的 GetAppID()
2.3 企微下返回参数跟企微 jssdk 使用保持一致，企微下 appId 的 key 名调整为 corpId

**估计该接口之前未有生产使用，修复后调用结果示例如下**
<img width="639" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/2382215/d9252dca-794e-4ea8-bc09-825c1a6d6df7">

**企微文档**
<img width="938" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/2382215/c8beb8da-09ad-4b9f-ba8d-cbfe28cfd6f6">



