### PR TITLE
fix(work): requestMessage mistake names fixed

### DIFF
--- a/src/work/externalContact/messageTemplate/request/requestMessage.go
+++ b/src/work/externalContact/messageTemplate/request/requestMessage.go
@@ -29,10 +29,10 @@ func (media *LinkOfMessage) GetMsgType() string {
 }
 
 type Link struct {
-	Title  string `json:"title"`   //  "消息标题",
-	PicURL string `json:"pic_url"` //  "https://example.pic.com/path",
-	Desc   string `json:"desc"`    //  "消息描述",
-	URL    string `json:"url"`     //  "https://example.link.com/path"
+	Title  string `json:"title"`  //  "消息标题",
+	PicURL string `json:"picurl"` //  "https://example.pic.com/path",
+	Desc   string `json:"desc"`   //  "消息描述",
+	URL    string `json:"url"`    //  "https://example.link.com/path"
 }
 
 type MiniProgramOfMessage struct {
@@ -56,7 +56,7 @@ type File struct {
 }
 type FileOfMessage struct {
 	MsgType string `json:"msgtype"` // "file"
-	Video   *File  `json:"file"`
+	File    *File  `json:"file"`
 }
 
 func (media *FileOfMessage) GetMsgType() string {
@@ -87,4 +87,8 @@ type Attachment struct {
 	MiniProgram *MiniProgram `json:"miniprogram,omitempty"`
 	Video       *Video       `json:"video,omitempty"`
 	File        *File        `json:"file,omitempty"`
+}
+
+func (attachment *Attachment) GetMsgType() string {
+	return attachment.MsgType
 }


### PR DESCRIPTION
1. 企业群发相关模型名称错误修复
1.1 Link Struct 的 json tag 修正：`pic_url -> picurl`
1.2 FileOfMessage Struct 修正 ：`Video -> File`
2. `Attachment` 支持 `MessageTemplateInterface`