### PR TITLE
Update responseMenuGet.go

### DIFF
--- a/src/officialAccount/menu/response/responseMenuGet.go
+++ b/src/officialAccount/menu/response/responseMenuGet.go
@@ -3,7 +3,7 @@ package response
 import "github.com/ArtisanCloud/PowerWeChat/v3/src/kernel/response"
 
 type Button struct {
-	Type       string    `json:"type"`
+	Type       string    `json:"type,omitempty"`
 	Name       string    `json:"name"`
 	Key        string    `json:"key"`
 	URL        string    `json:"url,omitempty"`


### PR DESCRIPTION
如果设置的二级菜单 那么父级就不会有type字段