### PR TITLE
feat(work): added state to GroupChat Member & improve externalChat event models

### DIFF
--- a/src/work/externalContact/groupChat/response/responseGroupChatGet.go
+++ b/src/work/externalContact/groupChat/response/responseGroupChatGet.go
@@ -13,6 +13,7 @@ type Member struct {
 	Type          int      `json:"type"`
 	JoinTime      int      `json:"join_time"`
 	JoinScene     int      `json:"join_scene"`
+	State         string   `json:"state"`
 	Invitor       *Invitor `json:"invitor,omitempty"`
 	GroupNickname string   `json:"group_nickname"`
 	Name          string   `json:"name"`

--- a/src/work/server/handlers/models/externalContact.go
+++ b/src/work/server/handlers/models/externalContact.go
@@ -73,6 +73,29 @@ type EventExternalUserDelFollowUser struct {
 	ExternalUserID string `xml:"ExternalUserID"`
 }
 
+type EventExternalChatCreate struct {
+	contract.EventInterface
+	models.CallbackMessageHeader
+	ChatID string `xml:"ChatId"`
+}
+
+type EventExternalChatUpdate struct {
+	contract.EventInterface
+	models.CallbackMessageHeader
+	ChatID       string `xml:"ChatId"`
+	UpdateDetail string `xml:"UpdateDetail"`
+	JoinScene    string `xml:"JoinScene"`
+	QuitScene    string `xml:"QuitScene"`
+	MemChangeCnt string `xml:"MemChangeCnt"`
+}
+
+type EventExternalChatDismiss struct {
+	contract.EventInterface
+	models.CallbackMessageHeader
+	ChatID string `xml:"ChatId"`
+}
+
+// Deprecated: Use EventExternalChatUpdate instead.
 type EventExternalUserUpdateAddMember struct {
 	contract.EventInterface
 	models.CallbackMessageHeader
@@ -84,6 +107,7 @@ type EventExternalUserUpdateAddMember struct {
 	MemChangeCnt string `xml:"MemChangeCnt"`
 }
 
+// Deprecated: Use EventExternalChatDismiss instead.
 type EventExternalUserDismiss struct {
 	contract.EventInterface
 	models.CallbackMessageHeader


### PR DESCRIPTION
## 获取客户群详情，返回state参数

[文档地址](https://developer.work.weixin.qq.com/document/path/92229#%E9%99%84%E5%BD%95%EF%BC%9A%E8%8E%B7%E5%8F%96%E5%AE%A2%E6%88%B7%E7%BE%A4%E8%AF%A6%E6%83%85%EF%BC%8C%E8%BF%94%E5%9B%9Estate%E5%8F%82%E6%95%B0)

**添加 State 属性**
```
type Member struct {
	UserID        string   `json:"userid"`
	Type          int      `json:"type"`
	JoinTime      int      `json:"join_time"`
	JoinScene     int      `json:"join_scene"`
	State         string   `json:"state"`  // 新增属性，标识添加渠道
	Invitor       *Invitor `json:"invitor,omitempty"`
	GroupNickname string   `json:"group_nickname"`
	Name          string   `json:"name"`
	UnionID       string   `json:"unionid,omitempty"`
}
```

## 客户群变更事件（分为创建/变更/解散）
[文档地址](https://developer.work.weixin.qq.com/document/path/92130#%E5%AE%A2%E6%88%B7%E7%BE%A4%E5%88%9B%E5%BB%BA%E4%BA%8B%E4%BB%B6)


**非 User 相关事件，使用 EventExternalChat** 开头重新定义模型（保留原模型）
```
// change to EventExternalChatUpdate，原模型保留并标注为 deprecated
// 非 User 相关事件，使用 EventExternalChatUpdate 语义话更好（update 即可，add_member 只是其中一种 UpdateDetail）
type EventExternalUserUpdateAddMember struct { 
	contract.EventInterface
	models.CallbackMessageHeader
	ChatID       string `xml:"ChatId"`
	ChangeType   string `xml:"ChangeType"` // CallbackMessageHeader 中存在，移除
	UpdateDetail string `xml:"UpdateDetail"`
	JoinScene    string `xml:"JoinScene"`
	QuitScene    string `xml:"QuitScene"`
	MemChangeCnt string `xml:"MemChangeCnt"`
}

// change to EventExternalChatDismiss，原模型保留标注为 deprecated
type EventExternalUserDismiss struct {
	contract.EventInterface
	models.CallbackMessageHeader
	ChatID string `xml:"ChatId"`
}
```

**新添加的新模型**
```
type EventExternalChatCreate struct {
	contract.EventInterface
	models.CallbackMessageHeader
	ChatID string `xml:"ChatId"`
}

type EventExternalChatUpdate struct {
	contract.EventInterface
	models.CallbackMessageHeader
	ChatID       string `xml:"ChatId"`
	UpdateDetail string `xml:"UpdateDetail"`
	JoinScene    string `xml:"JoinScene"`
	QuitScene    string `xml:"QuitScene"`
	MemChangeCnt string `xml:"MemChangeCnt"`
}

type EventExternalChatDismiss struct {
	contract.EventInterface
	models.CallbackMessageHeader
	ChatID string `xml:"ChatId"`
}
```

**为避免对现有使用的用户产生影响，保留原模型但标注 deprecated，使用时给出提示**

<img width="636" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/2382215/df76880e-a2bf-46e6-a106-79e01c5048f4">

<img width="408" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/2382215/94f556bd-9951-472a-a945-07e39c4fb10f">
