### PR TITLE
更新发布文章API接口PublishId参数类型

### DIFF
--- a/src/officialAccount/publish/client.go
+++ b/src/officialAccount/publish/client.go
@@ -122,7 +122,7 @@ func (comp *Client) PublishSubmit(ctx context.Context, mediaID string) (*respons
 
 // 发布状态轮询接口
 // https://developers.weixin.qq.com/doc/offiaccount/Publish/Get_status.html
-func (comp *Client) PublishGet(ctx context.Context, publishID string) (*response.ResponsePublishGet, error) {
+func (comp *Client) PublishGet(ctx context.Context, publishID uint64) (*response.ResponsePublishGet, error) {
 	result := &response.ResponsePublishGet{}
 
 	_, err := comp.BaseClient.HttpPostJson(ctx, "cgi-bin/freepublish/get", &object.HashMap{

--- a/src/officialAccount/publish/response/responsePublish.go
+++ b/src/officialAccount/publish/response/responsePublish.go
@@ -5,7 +5,7 @@ import "github.com/ArtisanCloud/PowerWeChat/v3/src/kernel/response"
 type ResponsePublishSubmit struct {
 	response.ResponseOfficialAccount
 
-	PublishId string `json:"publish_id"`
+	PublishId uint64 `json:"publish_id"`
 }
 
 type ArticleItem struct {
@@ -21,7 +21,7 @@ type ArticleDetail struct {
 type ResponsePublishGet struct {
 	response.ResponseOfficialAccount
 
-	PublishId     string         `json:"publish_id"`
+	PublishId     uint64         `json:"publish_id"`
 	PublishStatus int            `json:"publish_status"`
 	ArticleId     interface{}    `json:"article_id"`
 	ArticleDetail *ArticleDetail `json:"article_detail"`


### PR DESCRIPTION
修正参数类型：公众号发布文章API接口返回的PublishId参数实际为数字型