### PR TITLE
修改GetApprovalInfo（批量获取审批单号）函数的传参filters为数组

### DIFF
--- a/src/work/oa/client.go
+++ b/src/work/oa/client.go
@@ -195,7 +195,7 @@ func (comp *Client) CreateApproval(ctx context.Context, data *power.HashMap) (*r
 
 // 批量获取审批单号
 // https://developer.work.weixin.qq.com/document/path/91816
-func (comp *Client) GetApprovalInfo(ctx context.Context, startTime int, endTime int, nextCursor int, size int, filters *object.HashMap) (*response.ResponseApprovalNoList, error) {
+func (comp *Client) GetApprovalInfo(ctx context.Context, startTime int, endTime int, nextCursor int, size int, filters []*object.HashMap) (*response.ResponseApprovalNoList, error) {
 
 	result := &response.ResponseApprovalNoList{}
 


### PR DESCRIPTION
GetApprovalInfo（批量获取审批单号）函数应该可以接收多个筛选条件
<img width="958" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/43365518/b28390d8-d572-447f-bcca-051608280e8b">
修改了filters参数为数组类型