### PR TITLE
fix: 企业微信客服发送菜单消息

### DIFF
--- a/src/work/accountService/message/request/requestAccountServiceSendMsg.go
+++ b/src/work/accountService/message/request/requestAccountServiceSendMsg.go
@@ -51,9 +51,10 @@ type RequestAccountServiceMsgMenu struct {
 	List        []RequestAccountServiceMsgMenuList `json:"list,omitempty"`
 }
 type RequestAccountServiceMsgMenuList struct {
-	Click       RequestAccountServiceMsgMenuListClick       `json:"click,omitempty"`
-	View        RequestAccountServiceMsgMenuListView        `json:"view,omitempty"`
-	MiniProgram RequestAccountServiceMsgMenuListMiniProgram `json:"miniprogram,omitempty"`
+	Type        string                                       `json:"type"`
+	Click       *RequestAccountServiceMsgMenuListClick       `json:"click,omitempty"`
+	View        *RequestAccountServiceMsgMenuListView        `json:"view,omitempty"`
+	MiniProgram *RequestAccountServiceMsgMenuListMiniProgram `json:"miniprogram,omitempty"`
 }
 type RequestAccountServiceMsgMenuListClick struct {
 	ID      string `json:"id"`


### PR DESCRIPTION
根据[文档](https://developer.work.weixin.qq.com/document/path/94677#%E8%8F%9C%E5%8D%95%E6%B6%88%E6%81%AF)，菜单的格式应该是


```json
            {
                "type": "click", 
                "click": {
                    "id": "101", 
                    "content": "满意"
                }
            }
```


另外，应该是可选