### PR TITLE
fix(kernel): baseClient timeout setting fixed

### DIFF
--- a/src/kernel/baseClient.go
+++ b/src/kernel/baseClient.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ArtisanCloud/PowerLibs/v3/http/contract"
 	"github.com/ArtisanCloud/PowerLibs/v3/http/helper"
@@ -53,6 +54,7 @@ func NewBaseClient(app *ApplicationInterface, token *AccessToken) (*BaseClient, 
 	config := (*app).GetConfig()
 	baseURI := config.GetString("http.base_uri", "/")
 	proxyURI := config.GetString("http.proxy_uri", "")
+	timeout := config.GetFloat64("http.timeout", 5)
 
 	if token == nil {
 		token = (*app).GetAccessToken()
@@ -60,6 +62,7 @@ func NewBaseClient(app *ApplicationInterface, token *AccessToken) (*BaseClient, 
 	h, err := helper.NewRequestHelper(&helper.Config{
 		BaseUrl: baseURI,
 		ClientConfig: &contract.ClientConfig{
+			Timeout:  time.Duration(timeout * float64(time.Second)),
 			ProxyURI: proxyURI,
 		},
 	})


### PR DESCRIPTION
## 接口的超时设置未生效问题修复
以下代码做了自定义 timeout 的设置，但在 baseClient 发起请求的地方，打印 http.Client 的 timeout 值实际为0

<img width="1018" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/2382215/fd2c5932-e752-4f12-903f-d061560a5314">

经测试验证 timeout 是 0，该设置未生效

<img width="1017" alt="image" src="https://github.com/ArtisanCloud/PowerWeChat/assets/2382215/dca73983-66c8-45b4-aaa7-e11cf559f04d">

## 问题修复
kernel -> baseClient NewRequestHelper 的 Config 配置，补充缺失的 timeout 参数设置
```
func NewBaseClient(app *ApplicationInterface, token *AccessToken) (*BaseClient, error) {

	config := (*app).GetConfig()
	baseURI := config.GetString("http.base_uri", "/")
	proxyURI := config.GetString("http.proxy_uri", "")
	timeout := config.GetFloat64("http.timeout", 5)

	if token == nil {
		token = (*app).GetAccessToken()
	}
	h, err := helper.NewRequestHelper(&helper.Config{
		BaseUrl: baseURI,
		ClientConfig: &contract.ClientConfig{
			Timeout:  time.Duration(timeout * float64(time.Second)),
			ProxyURI: proxyURI,
		},
	})

```
