### PR TITLE
fix: 修复 RequestAccountServiceMsgMenuList 结构体中 json 序列化发送消息的时候，应该 omitempty 的数据没有 omitempty 的问题

### DIFF
--- a/src/work/accountService/message/request/requestAccountServiceSendMsg.go
+++ b/src/work/accountService/message/request/requestAccountServiceSendMsg.go
@@ -51,10 +51,10 @@ type RequestAccountServiceMsgMenu struct {
 	List        []RequestAccountServiceMsgMenuList `json:"list,omitempty"`
 }
 type RequestAccountServiceMsgMenuList struct {
-	Type        string                                      `json:"type"`
-	Click       RequestAccountServiceMsgMenuListClick       `json:"click,omitempty"`
-	View        RequestAccountServiceMsgMenuListView        `json:"view,omitempty"`
-	MiniProgram RequestAccountServiceMsgMenuListMiniProgram `json:"miniprogram,omitempty"`
+	Type        string                                       `json:"type"`
+	Click       *RequestAccountServiceMsgMenuListClick       `json:"click,omitempty"`
+	View        *RequestAccountServiceMsgMenuListView        `json:"view,omitempty"`
+	MiniProgram *RequestAccountServiceMsgMenuListMiniProgram `json:"miniprogram,omitempty"`
 }
 type RequestAccountServiceMsgMenuListClick struct {
 	ID      string `json:"id"`


### PR DESCRIPTION
如果不修改，对于如下的调用代码
```Golang
options := &request.RequestAccountServiceSendMsg{
		ToUser:   "wmDMteDAAA6-BPjDYLDQDhmuB9X0FAqg",
		OpenKfid: "wkDMteDAAA7w7-OXWjYPPDnVXMZF73vw",
		MsgID:    RandStringBytes(12),
		MsgType:  "msgmenu",
		Menu: &request.RequestAccountServiceMsgMenu{
			HeadContent: "您好，请问有什么可以帮到您？",
			TailContent: "请点击菜单选择服务",
			List: []request.RequestAccountServiceMsgMenuList{
				{
					Type: "click",
					Click: request.RequestAccountServiceMsgMenuListClick{
						ID:      "101",
						Content: "Haoppy",
					},
				},
			},
		},
	}
WeComApp.AccountServiceMessage.SendMsg(context.Background(), options)
```
产生的请求包如下
```json
{
    "touser": "wmDMteDAAA6-BPjDYLDQDhmuB9X0FAqg", 
    "open_kfid": "wkDMteDAAA7w7-OXWjYPPDnVXMZF73vw", 
    "msgid": "VEzERTIWxnLP", 
    "msgtype": "msgmenu", 
    "msgmenu": {
        "head_content": "您好，请问有什么可以帮到您？", 
        "tail_content": "请点击菜单选择服务", 
        "list": [
            {
                "type": "click", 
                "click": {
                    "id": "101", 
                    "content": "Haoppy"
                }, 
                "view": {
                    "url": "", 
                    "content": ""
                }, 
                "miniprogram": {
                    "appid": "", 
                    "pagepath": "", 
                    "content": ""
                }
            }
        ]
    }
}
```

这里 `view` 和 `miniprogram` 是不应该出现的，导致微信服务侧返回报错
```json
{"errcode":40058,"errmsg":"msgmenu.list.view.url exceed min length 1. invalid Request Parameter, hint: [1721033037419200687955096], from ip: 112.91.80.51, more info at https://open.work.weixin.qq.com/devtool/query?e=40058"}
```

这里应该给这几个 omitempty 的属性改为指针类型