### PR TITLE
fixed: 公众号基础菜单中未包含Url,导致基础菜单设置Url的情况无法获得相应的返回信息。

### DIFF
--- a/src/officialAccount/menu/response/responseMenuCurrentSelf.go
+++ b/src/officialAccount/menu/response/responseMenuCurrentSelf.go
@@ -32,6 +32,7 @@ type SelfButton struct {
 	Name       string     `json:"name"`
 	Key        string     `json:"key"`
 	Value      string     `json:"value,omitempty"`
+	URL        string `json:"url,omitempty"`
 	SubButtons *SubButton `json:"sub_button"`
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7b9fde00-7b12-4b54-b1d7-3d4fc7201a43)
当为根目录时
![image](https://github.com/user-attachments/assets/a0255841-3908-4f1c-a28b-d4561df83cde)
url无法渲染导致页面返回信息url无填充，增加URL返回key即可。
