### PR TITLE
fix(openPlatform): MiniProgram auth client init & GetQrCode fixed

### DIFF
--- a/src/openPlatform/application.go
+++ b/src/openPlatform/application.go
@@ -295,7 +295,7 @@ func (app *OpenPlatform) MiniProgram(appID string, refreshToken string, accessTo
 		app.Config.GetString("token", ""),
 		app.Config.GetString("aes_key", ""),
 	)
-	application.Auth, err = auth3.NewClient(app, application)
+	application.Auth, err = auth3.NewClient(application, app)
 
 	return application, err
 

--- a/src/openPlatform/authorizer/miniProgram/code/client.go
+++ b/src/openPlatform/authorizer/miniProgram/code/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ArtisanCloud/PowerLibs/v3/object"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/kernel"
 	response2 "github.com/ArtisanCloud/PowerWeChat/v3/src/kernel/response"
+	response4 "github.com/ArtisanCloud/PowerWeChat/v3/src/work/media/response"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/openPlatform/authorizer/miniProgram/code/request"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/openPlatform/authorizer/miniProgram/code/response"
 	"net/http"
@@ -44,16 +45,16 @@ func (comp *Client) Commit(ctx context.Context, templateID string, extJson strin
 
 // 获取体验版二维码
 // https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/code/get_qrcode.html
-func (comp *Client) GetQrCode(ctx context.Context, path string) (*response2.ResponseOpenPlatform, error) {
+func (comp *Client) GetQrCode(ctx context.Context, path string) (*http.Response, error) {
 
-	result := &response2.ResponseOpenPlatform{}
+	var header = &response4.ResponseHeaderMedia{}
 
-	_, err := comp.BaseClient.RequestRaw(ctx, "wxa/get_qrcode", http.MethodPost, &object.HashMap{
+	rs, err := comp.BaseClient.RequestRaw(ctx, "wxa/get_qrcode", http.MethodGet, &object.HashMap{
 		"query": &object.StringMap{
 			"path": path,
-		}}, nil, result)
+		}}, &header, nil)
 
-	return result, err
+	return rs, err
 
 }
 


### PR DESCRIPTION
<img width="963" alt="image" src="https://github.com/user-attachments/assets/63987bd6-efc6-484b-a809-bb28ce702414" />

1. 因为 OpenPlatform 获取小程序实例时，auth3.NewClient  传参传反了，导致请求 Auth.Session（获取 openId 接口）的代码段， 抛出 `*auth.AccessToken` 类型不一致的错误。
2. 修复获取体验小程序码的接口问题，请求类型是 Get，返回的是图片二进制

