### PR TITLE
fix(miniProgram/ocr): changed the type of the ImgSize field

### DIFF
--- a/src/miniProgram/ocr/response/ResponseOCRPrintedText.go
+++ b/src/miniProgram/ocr/response/ResponseOCRPrintedText.go
@@ -8,5 +8,5 @@ import (
 type ResponseOCRPrintedText struct {
 	response.ResponseMiniProgram
 	Items   []*power.HashMap `json:"items"`
-	ImgSize []*power.HashMap `json:"img_size"`
+	ImgSize *power.HashMap   `json:"img_size"`
 }


### PR DESCRIPTION
This ensures that the image size information returned by the OCR interface is correctly parsed.

#687 