### PR TITLE
公众号一级菜单缺失bug修复

### DIFF
--- a/src/officialAccount/menu/response/responseMenuCurrentSelf.go
+++ b/src/officialAccount/menu/response/responseMenuCurrentSelf.go
@@ -34,6 +34,10 @@ type SelfButton struct {
 	Key        string     `json:"key"`
 	Value      string     `json:"value,omitempty"`
 	URL        string     `json:"url,omitempty"`
+	MediaId    string     `json:"media_id,omitempty"`
+	Appid      string     `json:"appid,omitempty"`
+	Pagepath   string     `json:"pagepath,omitempty"`
+	ArticleId  string     `json:"article_id,omitempty"`
 	SubButtons *SubButton `json:"sub_button"`
 }
 


### PR DESCRIPTION
公众号一级菜单少了 小程序设置等其他参数
<img width="1244" height="834" alt="image" src="https://github.com/user-attachments/assets/d678942f-47d4-4a9d-8ca1-6aeef170c30d" />
