### PR TITLE
fix(openplatform): set default release body to {}

### DIFF
--- a/src/openPlatform/authorizer/miniProgram/code/client.go
+++ b/src/openPlatform/authorizer/miniProgram/code/client.go
@@ -2,13 +2,14 @@ package code
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/ArtisanCloud/PowerLibs/v3/object"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/kernel"
 	response2 "github.com/ArtisanCloud/PowerWeChat/v3/src/kernel/response"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/openPlatform/authorizer/miniProgram/code/request"
 	"github.com/ArtisanCloud/PowerWeChat/v3/src/openPlatform/authorizer/miniProgram/code/response"
 	response4 "github.com/ArtisanCloud/PowerWeChat/v3/src/work/media/response"
-	"net/http"
 )
 
 type Client struct {
@@ -128,7 +129,7 @@ func (comp *Client) Release(ctx context.Context) (*response2.ResponseOpenPlatfor
 
 	result := &response2.ResponseOpenPlatform{}
 
-	_, err := comp.BaseClient.HttpPostJson(ctx, "wxa/release", nil, nil, nil, result)
+	_, err := comp.BaseClient.HttpPostJson(ctx, "wxa/release", &object.HashMap{}, nil, nil, result)
 
 	return result, err
 


### PR DESCRIPTION
修复 Release body 参数透传错误的问题

<img width="824" height="134" alt="image" src="https://github.com/user-attachments/assets/3618f073-8e66-48b4-a4ef-f37e06af6454" />

微信文档地址：https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/code-management/release.html
